### PR TITLE
PHP error fix + more

### DIFF
--- a/class.wp-help-pointers.php
+++ b/class.wp-help-pointers.php
@@ -59,7 +59,19 @@ class WP_Help_Pointer {
 
     public function register_pointers( $pntrs ) {
        
+        $pointers = $this->pointers;
+    
         foreach( $pntrs as $ptr ) {
+            
+            // show in all screens if not specified
+            if ( empty($ptr['screen']) ) {
+                  $screen = get_current_screen();
+                  $ptr['screen'] = $screen->id;
+            }
+            // if no id is specified, generate a unique one
+            if ( empty($ptr['id']) ) {
+                $ptr['id'] = md5( $ptr['title'] . $ptr['content'] );
+            }
                 
             if( $ptr['screen'] == $this->screen_id ) {
                
@@ -78,7 +90,7 @@ class WP_Help_Pointer {
             }
         }
 
-         $this->pointers = $pointers;
+        $this->pointers = $pointers;
 
     }
 


### PR DESCRIPTION
Fixed PHP undefined variable error. Enhancements: if screen is not
specified, pointer is displayed in all screens. If no id is specified,
a unique id is generated.
